### PR TITLE
Removed usage of !important

### DIFF
--- a/assets/stylesheets/progressive_projects_list.css
+++ b/assets/stylesheets/progressive_projects_list.css
@@ -1,5 +1,5 @@
-ul.progressive-project-menu {
-	padding-left: 0 !important;
+ul.projects ul.progressive-project-menu {
+	padding-left: 0;
 }
 ul.progressive-project-menu li {
 	float:left;


### PR DESCRIPTION
This rule produces the same output, but the !important rule is obsolete. This is much cleaner, as if designers try to overwrite this in their own themes.
