### PR TITLE
Update project_decorator.rb

### DIFF
--- a/lib/progressive/project_decorator.rb
+++ b/lib/progressive/project_decorator.rb
@@ -27,7 +27,7 @@ module Progressive::ProjectDecorator
       if issues.count > 0
         ratio = open ? 'done_ratio' : 100
 
-        done = issues.sum("COALESCE(estimated_hours, #{estimated_average}) * #{ratio}",
+        done = issues.sum("COALESCE(CASE WHEN estimated_hours > 0 THEN estimated_hours ELSE NULL END, #{estimated_average}) * #{ratio}",
                                   :joins => :status,
                                   :conditions => ["#{IssueStatus.table_name}.is_closed = ?", !open]).to_f
         progress = done / (estimated_average * issues.count)


### PR DESCRIPTION
Ported redmine Rev12131 to this plugin.
http://www.redmine.org/projects/redmine/repository/revisions/12131/diff/trunk/app/models/issue.rb

I've detected, that the calculation will break if the estimated_hours were entered, but be just 0. This will cause some weird side effects. This should fix that.
