### PR TITLE
Add a setting that allows to calculate progress based on tickets ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
 Progressive Projects List
 =========================
 
-[![Rate at redmine.org](http://img.shields.io/badge/rate%20at-redmine.org-blue.svg?style=flat)](http://www.redmine.org/plugins/progressive-projects-list)
-
-Plugin loads [Redmine](http://www.redmine.org/)'s projects list with overall projects status.
-
-One of the [5 Redmine Plugins that will change the way you work](http://it-consultis.com/blog/5-redmine-plugins-will-change-way-work/) by [Thomas Guillemaud](http://it-consultis.com/author/thomas/) from [IT Consultis]
-(http://it-consultis.com/).
+Projects list with blackjack and other features for [Redmine](http://www.redmine.org/).
 
 Features
 --------
 
-- Show overall projects status in progress bars
+- Show overall projects status in progress bars (progress can be calculated based on the hours spent/left or simply on the ratio of tickets closed - configurable)
 - Show project status in progress bars at project overview page
 - Quick links to issues, new issue, version, etc directly from the projects list
 - Show due date of the projects and versions
 - Recently viewed projects sidebar block
 - Configurable: admin set default settings, user may override them per session
-- Translated into 12 languages: English, German, French, Italian, Spanish, Portuguese, Traitional and Simplified Chinese, Japanese, Russian, Ukrainian, Polish.
+- Translated into 7 languages: English, German, French, Italian, Simplified Chinese, Russian, Ukrainian.
 
 ![Progressive Projects List Screenshot](http://stgeneral.github.io/redmine-progressive-projects-list/images/screenshots/v020/progressive-projects-list-v020-progress.png)
 
@@ -26,38 +21,15 @@ More details and screenshots - http://stgeneral.github.io/redmine-progressive-pr
 Installation notes
 ------------------
 
-1. Download [latest release](https://github.com/stgeneral/redmine-progressive-projects-list/releases/latest) of the plugin.
-2. Extract it to `<redmine_path>/plugins`. You should get `<redmine_path>/plugins/progressive_projects_list` directory.
-3. Restart Redmine.
+Plugin's directory should be named progressive_projects_list exactly.
+Other installation instructions are generic and can be found at [Redmine Plugins page](http://www.redmine.org/projects/redmine/wiki/Plugins).
 
-You should now be able to see the plugin list in _Administration -> Plugins_ and configure it.
+Compatible with Redmine 2.4, 2.3, 2.2, 2.1.
+For ChiliProject 3.4 use [version 0.5.1](https://github.com/stgeneral/redmine-progressive-projects-list/releases/tag/v0.5.1).
 
-Generic instructions for installing/uninstalling plugins can be found at [Redmine Plugins page](http://www.redmine.org/projects/redmine/wiki/Plugins).
-
-### Compatibility ###
-
-- Redmine 3.0 .. 3.2 - [version 3.0.1](https://github.com/stgeneral/redmine-progressive-projects-list/releases/tag/v3.0.1) and branch [master](https://github.com/stgeneral/redmine-progressive-projects-list/tree/master).
-- Redmine 2.3 .. 3.0 - [version 2.0.1](https://github.com/stgeneral/redmine-progressive-projects-list/releases/tag/v2.0.1).
-- Redmine 2.1 .. 2.6 - [version 1.1.0](https://github.com/stgeneral/redmine-progressive-projects-list/releases/tag/v1.1.0) and branch [version-1](https://github.com/stgeneral/redmine-progressive-projects-list/tree/version-1).
-- ChiliProject 3.4 - [version 0.5.1](https://github.com/stgeneral/redmine-progressive-projects-list/releases/tag/v0.5.1) and branch [version-0](https://github.com/stgeneral/redmine-progressive-projects-list/tree/version-0).
-
-Proressive plugins for Redmine
-------------------------------
+Other Proressive plugins for Redmine
+------------------------------------
 
 * [Progressive Projects List](http://stgeneral.github.io/redmine-progressive-projects-list/) - overall projects status on one page.
 * [Progressive Redmine Theme](http://stgeneral.github.io/redmine-progressive-theme/) - extends default theme with some nice features.
 * [Progressive Gantt Mods](http://stgeneral.github.io/redmine-progressive-gantt-mods/) - assignee column and some preferences for Gantt chart.
-* [Collapsed Journals Plugin](https://github.com/stgeneral/redmine-collapsed-journals) - collapses issue history items without an assosiated note
-
-License
--------
-
-*The MIT License (MIT)*
-
-Copyright (c) 2012-2016 Dmitry Babenko
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/app/views/projects/_progressive_sidebar.html.erb
+++ b/app/views/projects/_progressive_sidebar.html.erb
@@ -9,9 +9,9 @@
 	<%= check_box_tag :show_project_progress, 1, progressive_setting?(:show_project_progress) %>
 		<%= label_tag :show_project_progress, l(:setting_show_project_progress) %><br />
 	<%= check_box_tag :show_only_for_my_projects, 1, progressive_setting?(:show_only_for_my_projects) %>
-		<%= label_tag :show_only_for_my_projects, l(:setting_show_only_for_my_projects)  %><br />
-	<%= check_box_tag :show_recent_projects, 1, progressive_setting?(:show_recent_projects) %>
-		<%= label_tag :show_recent_projects, l(:setting_show_recent_projects)  %>
+		<%= label_tag :show_only_for_my_projects, l(:setting_show_only_for_my_projects)  %>
+	<%= check_box_tag :ignore_hours, 1, progressive_setting?(:ignore_hours) %>
+		<%= label_tag :ignore_hours, l(:setting_ignore_hours)  %>
 
 	<p><%= submit_tag l(:button_apply), :class => 'button-small', :name => nil %></p>
 	<% end %>

--- a/app/views/settings/_progressive_projects_list.html.erb
+++ b/app/views/settings/_progressive_projects_list.html.erb
@@ -17,6 +17,10 @@
 		<%= check_box_tag('settings[show_only_for_my_projects]', true, @settings['show_only_for_my_projects']) %>
 	</p>
 	<p>
+		<%= setting_label(:ignore_hours) %>
+		<%= check_box_tag('settings[ignore_hours]', true, @settings['ignore_hours']) %>
+	</p>
+	<p>
 		<%= setting_label(:show_project_progress_overview) %>
 		<%= select_tag('settings[show_project_progress_overview]',
 			options_for_select([
@@ -24,9 +28,5 @@
 				[l(:progressive_option_left), 'left'],
 				[l(:progressive_option_right), 'right']],
 			@settings['show_project_progress_overview'])) %>
-	</p>
-	<p>
-		<%= setting_label(:show_recent_projects) %>
-		<%= check_box_tag('settings[show_recent_projects]', true, @settings['show_recent_projects']) %>
 	</p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
   setting_show_project_progress_overview: Show progress on overview page
   setting_show_project_menu: Show projects' menu
   setting_show_only_for_my_projects: Show only for my projects
-  setting_show_recent_projects: Show 'Recently viewed projects'
+  setting_ignore_hours: Compute progress projects by ignoring hours spent on issues
   progressive_settings_hint: Defaults settings. Users may override them per session.
   label_progress: Progress
   progressive_option_left: Left

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,12 +1,12 @@
 fr:
   setting_show_project_description: Afficher la description des projets
   setting_show_project_progress: Afficher la progression des projets
-  setting_show_project_progress_overview: Afficher la progression sur la page d'aperçu
+  setting_show_project_progress_overview: Afficher le progrès dans la fenêtre d'aperçu
   setting_show_project_menu: Afficher le menu des projets
   setting_show_only_for_my_projects: Afficher seulement pour mes projets
-  setting_show_recent_projects: Afficher 'Projets vus récemment'
+  setting_ignore_hours: Calculer le progrès du projet en ignorant les heures imputées
   progressive_settings_hint: Configuration par défaut. Les utilisateurs peuvent la modifier pendant leur session courante.
-  label_progress: Progression
+  label_progress: Progrès
   progressive_option_left: à gauche
   progressive_option_right: à droite
   label_recent_projects: Projets vus récemment

--- a/init.rb
+++ b/init.rb
@@ -6,23 +6,22 @@ Redmine::Plugin.register :progressive_projects_list do
   name 'Progressive Projects List plugin'
   author 'Dmitry Babenko'
   description 'Projects List with menus and progress bars.'
-  version '3.0.1'
+  version '1.0.0'
   url 'http://stgeneral.github.io/redmine-progressive-projects-list/'
   author_url 'https://github.com/stgeneral'
-  requires_redmine :version_or_higher => '3.0'
+  requires_redmine :version_or_higher => '2.1.0'
 
   settings :default => {
     'show_project_description'  => false,
     'show_project_progress'     => true,
     'show_project_menu'         => false,
     'show_only_for_my_projects' => false,
-    'show_recent_projects'      => true,
-    'show_project_progress_overview' => ''
+    'show_project_progress_overview' => '',
+    'ignore_hours' => false
   }, :partial => 'settings/progressive_projects_list'
 end
 
 require 'progressive_projects_list'
-require 'progressive/application_helper_patch'
 require 'progressive/projects_helper_patch'
 require 'progressive/projects_list_view_listener'
 require 'progressive/recent_projects_view_listener'


### PR DESCRIPTION
I added a new setting that bypasses the calculation of the project progress based on the hours spents/left and does a simple ratio ( tickets closed / tickets count ). Your plugin is very useful but we don't use the hours in our issues at my company. 
I made it configurable so anyone can choose between any of the two methods.